### PR TITLE
correct check for writeability of prefs file

### DIFF
--- a/vizigrep/guiapp/guiapp.py
+++ b/vizigrep/guiapp/guiapp.py
@@ -30,9 +30,12 @@ class GuiApp:
             return
 
         path = os.path.join(self.appHomeDir, self.shortName + '.prefs')
-        if not os.access(path, os.W_OK):
-            self.__homeDirError(path)
-            return
+        try:
+            fp = open(path)
+        except IOError as e:
+            if e.errno == errno.EACCES:
+                self.__homeDirError(path)
+                return
 
     def __homeDirError(self, path):
         msg = 'Your user does not have write permission for file %s, this means %s will be unable to save preferences and data' % (path, self.shortName)


### PR DESCRIPTION
This PR corrects the check for writeability of the .config prefs file, so the program doesn't display a wrong error on first run.

using `os.access` always returns false if a file doesn't exist 
https://stackoverflow.com/questions/27434643/check-the-permissions-of-a-file-in-python